### PR TITLE
fix: use Makefile target for CLI format check in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,7 +79,7 @@ jobs:
           restore-keys: ${{ runner.os }}-cargo-cli-
 
       - name: Check formatting
-        run: cargo +nightly fmt -p zcash-wallet-cli --check
+        run: make format-check-cli
 
       - name: Lint
         run: make lint-cli

--- a/Makefile
+++ b/Makefile
@@ -107,6 +107,11 @@ format-check-rust: ## Check Rust formatting
 	@echo "Checking Rust formatting..."
 	cargo +nightly fmt --all --check
 
+.PHONY: format-check-cli
+format-check-cli: ## Check CLI Rust formatting
+	@echo "Checking CLI formatting..."
+	cargo +nightly fmt -p zcash-wallet-cli --check
+
 .PHONY: format-check-toml
 format-check-toml: ## Check TOML formatting with taplo
 	@echo "Checking TOML formatting..."


### PR DESCRIPTION
## Summary

- Add `format-check-cli` target to Makefile
- Update CI workflow to use `make format-check-cli` instead of direct cargo command

Fixes #111