### PR TITLE
feat: show both address types in Simple view Receive dialog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,29 +16,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - **Simple View**: New default view with clean interface for everyday users
-  - Balance display with Mainnet/Testnet indicator
-  - Receive functionality with address copy
-  - Send transparent transactions
-  - Recent transactions with timestamps and explorer links
+	- Balance display with Mainnet/Testnet indicator
+	- Receive functionality with address copy
+	- Send transparent transactions
+	- Recent transactions with timestamps and explorer links
 - **Wallet Management**
-  - Generate new wallets (24-word BIP39 seed phrases)
-  - Restore existing wallets from seed phrase
-  - Support for both Mainnet and Testnet
-  - Multiple wallet support
+	- Generate new wallets (24-word BIP39 seed phrases)
+	- Restore existing wallets from seed phrase
+	- Support for both Mainnet and Testnet
+	- Multiple wallet support
 - **Transaction Scanning**
-  - Scan transactions using viewing keys
-  - Decrypt shielded outputs (Sapling & Orchard)
-  - Track notes with spent/unspent status
-  - Balance breakdown by pool (Transparent, Sapling, Orchard)
+	- Scan transactions using viewing keys
+	- Decrypt shielded outputs (Sapling & Orchard)
+	- Track notes with spent/unspent status
+	- Balance breakdown by pool (Transparent, Sapling, Orchard)
 - **Address Derivation**
-  - Derive transparent addresses (t1/tm)
-  - Derive unified addresses (u1/utest1)
-  - Duplicate address detection (Sapling diversifier behavior)
-  - Save addresses to wallet for scanning
-  - Export as CSV
+	- Derive transparent addresses (t1/tm)
+	- Derive unified addresses (u1/utest1)
+	- Duplicate address detection (Sapling diversifier behavior)
+	- Save addresses to wallet for scanning
+	- Export as CSV
 - **Accountant View**
-  - Transaction ledger with running balance
-  - Export to CSV for tax reporting
+	- Transaction ledger with running balance
+	- Export to CSV for tax reporting
 - **Admin View**: Full-featured interface for power users
 - **Dark/Light mode** with system preference detection
 - **Mobile-friendly interface** with responsive design

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Show both unified and transparent addresses in Simple view Receive dialog
+- Show both unified and transparent addresses in Simple view Receive dialog ([#113](https://github.com/LeakIX/zcash-web-wallet/issues/113), [#114](https://github.com/LeakIX/zcash-web-wallet/pull/114))
 
 ## [0.1.0] - 2025-12-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,29 +16,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - **Simple View**: New default view with clean interface for everyday users
-	- Balance display with Mainnet/Testnet indicator
-	- Receive functionality with address copy
-	- Send transparent transactions
-	- Recent transactions with timestamps and explorer links
+  - Balance display with Mainnet/Testnet indicator
+  - Receive functionality with address copy
+  - Send transparent transactions
+  - Recent transactions with timestamps and explorer links
 - **Wallet Management**
-	- Generate new wallets (24-word BIP39 seed phrases)
-	- Restore existing wallets from seed phrase
-	- Support for both Mainnet and Testnet
-	- Multiple wallet support
+  - Generate new wallets (24-word BIP39 seed phrases)
+  - Restore existing wallets from seed phrase
+  - Support for both Mainnet and Testnet
+  - Multiple wallet support
 - **Transaction Scanning**
-	- Scan transactions using viewing keys
-	- Decrypt shielded outputs (Sapling & Orchard)
-	- Track notes with spent/unspent status
-	- Balance breakdown by pool (Transparent, Sapling, Orchard)
+  - Scan transactions using viewing keys
+  - Decrypt shielded outputs (Sapling & Orchard)
+  - Track notes with spent/unspent status
+  - Balance breakdown by pool (Transparent, Sapling, Orchard)
 - **Address Derivation**
-	- Derive transparent addresses (t1/tm)
-	- Derive unified addresses (u1/utest1)
-	- Duplicate address detection (Sapling diversifier behavior)
-	- Save addresses to wallet for scanning
-	- Export as CSV
+  - Derive transparent addresses (t1/tm)
+  - Derive unified addresses (u1/utest1)
+  - Duplicate address detection (Sapling diversifier behavior)
+  - Save addresses to wallet for scanning
+  - Export as CSV
 - **Accountant View**
-	- Transaction ledger with running balance
-	- Export to CSV for tax reporting
+  - Transaction ledger with running balance
+  - Export to CSV for tax reporting
 - **Admin View**: Full-featured interface for power users
 - **Dark/Light mode** with system preference detection
 - **Mobile-friendly interface** with responsive design

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- Show both unified and transparent addresses in Simple view Receive dialog
+
 ## [0.1.0] - 2025-12-30
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -112,6 +112,8 @@ Note: `make test` runs both `make test-rust` (unit tests for core, wasm, cli) an
 ### Changelog
 
 - **Every bug fix or feature must have a CHANGELOG.md entry**
+- **CHANGELOG entry must be in a separate commit** from the code changes
+- **Always include issue and PR references** in the entry: `([#issue](url), [#PR](url))`
 - Follow [Keep a Changelog](https://keepachangelog.com/) format
 - Add entries under `## [Unreleased]` section
 - Categories: `Added`, `Changed`, `Deprecated`, `Removed`, `Fixed`, `Security`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,7 +87,7 @@ Browser                                        Zcash Node
 
 ### Formatting
 
-- Run `make format` before committing
+- **Always run `make format` before every commit and push**
 - Rust: `cargo +nightly fmt`
 - JS/HTML: `prettier --write`
 - Sass: indented syntax has strict formatting rules (no automated formatter)

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -234,49 +234,87 @@
               ></button>
             </div>
             <div class="modal-body">
-              <p class="text-body-secondary mb-3 text-center">
-                Share an address to receive ZEC
-              </p>
+              <!-- Address Type Tabs -->
+              <ul class="nav nav-pills nav-fill mb-3" role="tablist">
+                <li class="nav-item" role="presentation">
+                  <button
+                    class="nav-link active"
+                    id="unified-tab"
+                    data-bs-toggle="pill"
+                    data-bs-target="#unified-pane"
+                    type="button"
+                    role="tab"
+                    aria-controls="unified-pane"
+                    aria-selected="true"
+                  >
+                    <i class="bi bi-shield-check me-1"></i>Unified
+                  </button>
+                </li>
+                <li class="nav-item" role="presentation">
+                  <button
+                    class="nav-link"
+                    id="transparent-tab"
+                    data-bs-toggle="pill"
+                    data-bs-target="#transparent-pane"
+                    type="button"
+                    role="tab"
+                    aria-controls="transparent-pane"
+                    aria-selected="false"
+                  >
+                    <i class="bi bi-eye me-1"></i>Transparent
+                  </button>
+                </li>
+              </ul>
 
-              <!-- Unified Address -->
-              <div class="mb-3">
-                <label class="form-label small fw-semibold">
-                  <i class="bi bi-shield-check me-1"></i>Unified Address
-                  (Recommended)
-                </label>
+              <!-- Tab Content -->
+              <div class="tab-content">
+                <!-- Unified Address Pane -->
                 <div
-                  id="receiveUnifiedAddressDisplay"
-                  class="mono small bg-body-tertiary p-3 rounded text-break"
-                  style="word-break: break-all"
+                  class="tab-pane fade show active"
+                  id="unified-pane"
+                  role="tabpanel"
+                  aria-labelledby="unified-tab"
                 >
-                  No wallet selected
+                  <div
+                    id="receiveUnifiedAddressDisplay"
+                    class="mono small bg-body-tertiary p-3 rounded text-break text-center"
+                    style="word-break: break-all"
+                  >
+                    No wallet selected
+                  </div>
+                  <div class="text-center mt-3">
+                    <button
+                      class="btn btn-outline-primary"
+                      id="copyUnifiedAddressBtn"
+                    >
+                      <i class="bi bi-clipboard me-1"></i>Copy Address
+                    </button>
+                  </div>
                 </div>
-                <button
-                  class="btn btn-outline-primary btn-sm mt-2"
-                  id="copyUnifiedAddressBtn"
-                >
-                  <i class="bi bi-clipboard me-1"></i>Copy Unified
-                </button>
-              </div>
 
-              <!-- Transparent Address -->
-              <div>
-                <label class="form-label small fw-semibold">
-                  <i class="bi bi-eye me-1"></i>Transparent Address
-                </label>
+                <!-- Transparent Address Pane -->
                 <div
-                  id="receiveTransparentAddressDisplay"
-                  class="mono small bg-body-tertiary p-3 rounded text-break"
-                  style="word-break: break-all"
+                  class="tab-pane fade"
+                  id="transparent-pane"
+                  role="tabpanel"
+                  aria-labelledby="transparent-tab"
                 >
-                  No wallet selected
+                  <div
+                    id="receiveTransparentAddressDisplay"
+                    class="mono small bg-body-tertiary p-3 rounded text-break text-center"
+                    style="word-break: break-all"
+                  >
+                    No wallet selected
+                  </div>
+                  <div class="text-center mt-3">
+                    <button
+                      class="btn btn-outline-primary"
+                      id="copyTransparentAddressBtn"
+                    >
+                      <i class="bi bi-clipboard me-1"></i>Copy Address
+                    </button>
+                  </div>
                 </div>
-                <button
-                  class="btn btn-outline-secondary btn-sm mt-2"
-                  id="copyTransparentAddressBtn"
-                >
-                  <i class="bi bi-clipboard me-1"></i>Copy Transparent
-                </button>
               </div>
             </div>
           </div>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -233,23 +233,51 @@
                 aria-label="Close"
               ></button>
             </div>
-            <div class="modal-body text-center">
-              <p class="text-body-secondary mb-3">
-                Share this address to receive ZEC
+            <div class="modal-body">
+              <p class="text-body-secondary mb-3 text-center">
+                Share an address to receive ZEC
               </p>
-              <div
-                id="receiveAddressDisplay"
-                class="mono small bg-body-tertiary p-3 rounded text-break mb-3"
-                style="word-break: break-all"
-              >
-                No wallet selected
+
+              <!-- Unified Address -->
+              <div class="mb-3">
+                <label class="form-label small fw-semibold">
+                  <i class="bi bi-shield-check me-1"></i>Unified Address
+                  (Recommended)
+                </label>
+                <div
+                  id="receiveUnifiedAddressDisplay"
+                  class="mono small bg-body-tertiary p-3 rounded text-break"
+                  style="word-break: break-all"
+                >
+                  No wallet selected
+                </div>
+                <button
+                  class="btn btn-outline-primary btn-sm mt-2"
+                  id="copyUnifiedAddressBtn"
+                >
+                  <i class="bi bi-clipboard me-1"></i>Copy Unified
+                </button>
               </div>
-              <button
-                class="btn btn-outline-primary"
-                id="copyReceiveAddressBtn"
-              >
-                <i class="bi bi-clipboard me-1"></i>Copy Address
-              </button>
+
+              <!-- Transparent Address -->
+              <div>
+                <label class="form-label small fw-semibold">
+                  <i class="bi bi-eye me-1"></i>Transparent Address
+                </label>
+                <div
+                  id="receiveTransparentAddressDisplay"
+                  class="mono small bg-body-tertiary p-3 rounded text-break"
+                  style="word-break: break-all"
+                >
+                  No wallet selected
+                </div>
+                <button
+                  class="btn btn-outline-secondary btn-sm mt-2"
+                  id="copyTransparentAddressBtn"
+                >
+                  <i class="bi bi-clipboard me-1"></i>Copy Transparent
+                </button>
+              </div>
             </div>
           </div>
         </div>

--- a/frontend/js/views.js
+++ b/frontend/js/views.js
@@ -546,7 +546,7 @@ export function initViewModeUI() {
           '<i class="bi bi-check me-1"></i>Copied!';
         setTimeout(() => {
           copyUnifiedAddressBtn.innerHTML =
-            '<i class="bi bi-clipboard me-1"></i>Copy Unified';
+            '<i class="bi bi-clipboard me-1"></i>Copy Address';
         }, 2000);
       }
     });
@@ -571,7 +571,7 @@ export function initViewModeUI() {
           '<i class="bi bi-check me-1"></i>Copied!';
         setTimeout(() => {
           copyTransparentAddressBtn.innerHTML =
-            '<i class="bi bi-clipboard me-1"></i>Copy Transparent';
+            '<i class="bi bi-clipboard me-1"></i>Copy Address';
         }, 2000);
       }
     });

--- a/frontend/js/views.js
+++ b/frontend/js/views.js
@@ -241,11 +241,18 @@ function updateSimpleTransactionList(walletId) {
 }
 
 export function updateReceiveAddress(walletId) {
-  const addressDisplay = document.getElementById("receiveAddressDisplay");
-  if (!addressDisplay) return;
+  const unifiedDisplay = document.getElementById(
+    "receiveUnifiedAddressDisplay"
+  );
+  const transparentDisplay = document.getElementById(
+    "receiveTransparentAddressDisplay"
+  );
+
+  if (!unifiedDisplay || !transparentDisplay) return;
 
   if (!walletId) {
-    addressDisplay.textContent = "No wallet selected";
+    unifiedDisplay.textContent = "No wallet selected";
+    transparentDisplay.textContent = "No wallet selected";
     return;
   }
 
@@ -253,13 +260,14 @@ export function updateReceiveAddress(walletId) {
   const wallet = wallets.find((w) => w.id === walletId);
 
   if (!wallet) {
-    addressDisplay.textContent = "Wallet not found";
+    unifiedDisplay.textContent = "Wallet not found";
+    transparentDisplay.textContent = "Wallet not found";
     return;
   }
 
-  const address =
-    wallet.unified_address || wallet.transparent_address || "No address";
-  addressDisplay.textContent = address;
+  unifiedDisplay.textContent = wallet.unified_address || "No unified address";
+  transparentDisplay.textContent =
+    wallet.transparent_address || "No transparent address";
 }
 
 // Get default RPC endpoint for a network
@@ -519,22 +527,51 @@ export function initViewModeUI() {
     });
   }
 
-  const copyReceiveAddressBtn = document.getElementById(
-    "copyReceiveAddressBtn"
+  // Copy unified address button
+  const copyUnifiedAddressBtn = document.getElementById(
+    "copyUnifiedAddressBtn"
   );
-  if (copyReceiveAddressBtn) {
-    copyReceiveAddressBtn.addEventListener("click", () => {
-      const addressDisplay = document.getElementById("receiveAddressDisplay");
+  if (copyUnifiedAddressBtn) {
+    copyUnifiedAddressBtn.addEventListener("click", () => {
+      const addressDisplay = document.getElementById(
+        "receiveUnifiedAddressDisplay"
+      );
       if (
         addressDisplay &&
-        addressDisplay.textContent !== "No wallet selected"
+        addressDisplay.textContent !== "No wallet selected" &&
+        addressDisplay.textContent !== "No unified address"
       ) {
         navigator.clipboard.writeText(addressDisplay.textContent);
-        copyReceiveAddressBtn.innerHTML =
+        copyUnifiedAddressBtn.innerHTML =
           '<i class="bi bi-check me-1"></i>Copied!';
         setTimeout(() => {
-          copyReceiveAddressBtn.innerHTML =
-            '<i class="bi bi-clipboard me-1"></i>Copy Address';
+          copyUnifiedAddressBtn.innerHTML =
+            '<i class="bi bi-clipboard me-1"></i>Copy Unified';
+        }, 2000);
+      }
+    });
+  }
+
+  // Copy transparent address button
+  const copyTransparentAddressBtn = document.getElementById(
+    "copyTransparentAddressBtn"
+  );
+  if (copyTransparentAddressBtn) {
+    copyTransparentAddressBtn.addEventListener("click", () => {
+      const addressDisplay = document.getElementById(
+        "receiveTransparentAddressDisplay"
+      );
+      if (
+        addressDisplay &&
+        addressDisplay.textContent !== "No wallet selected" &&
+        addressDisplay.textContent !== "No transparent address"
+      ) {
+        navigator.clipboard.writeText(addressDisplay.textContent);
+        copyTransparentAddressBtn.innerHTML =
+          '<i class="bi bi-check me-1"></i>Copied!';
+        setTimeout(() => {
+          copyTransparentAddressBtn.innerHTML =
+            '<i class="bi bi-clipboard me-1"></i>Copy Transparent';
         }, 2000);
       }
     });


### PR DESCRIPTION
## Summary

- Display both unified and transparent addresses in the Receive modal
- Unified address marked as recommended
- Separate copy buttons for each address type

Fixes #113