### PR TITLE
CI: add macos-latest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,10 @@ jobs:
           components: rustfmt, clippy
           targets: wasm32-unknown-unknown
 
+      - name: Install LLVM (macOS)
+        if: runner.os == 'macOS'
+        run: brew install llvm
+
       - name: Install wasm-pack
         run: make install-wasm-pack
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,8 +11,11 @@ env:
 
 jobs:
   rust:
-    name: Rust WASM Build & Test
-    runs-on: ubuntu-latest
+    name: Rust WASM Build & Test (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
     steps:
       - uses: actions/checkout@v4
 
@@ -52,12 +55,15 @@ jobs:
       - name: Upload WASM artifact
         uses: actions/upload-artifact@v4
         with:
-          name: wasm-pkg
+          name: wasm-pkg-${{ matrix.os }}
           path: frontend/pkg/
 
   cli:
-    name: CLI Build & Test
-    runs-on: ubuntu-latest
+    name: CLI Build & Test (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
     steps:
       - uses: actions/checkout@v4
 
@@ -91,8 +97,11 @@ jobs:
         run: make build-cli
 
   frontend:
-    name: Frontend Build & Lint
-    runs-on: ubuntu-latest
+    name: Frontend Build & Lint (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
     steps:
       - uses: actions/checkout@v4
 
@@ -114,7 +123,7 @@ jobs:
       - name: Upload CSS artifact
         uses: actions/upload-artifact@v4
         with:
-          name: css
+          name: css-${{ matrix.os }}
           path: frontend/css/
 
   build-complete:

--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,18 @@ build: build-wasm build-cli build-sass ## Build WASM module, CLI, and CSS
 .PHONY: build-wasm
 build-wasm: ## Build WASM module with wasm-pack
 	@echo "Building WASM module..."
+ifeq ($(shell uname),Darwin)
+	@if [ -d "$$(brew --prefix llvm 2>/dev/null)" ]; then \
+		LLVM_PREFIX=$$(brew --prefix llvm); \
+		CC="$$LLVM_PREFIX/bin/clang" AR="$$LLVM_PREFIX/bin/llvm-ar" \
+		sh -c 'cd wasm-module && wasm-pack build --target web --release --out-dir ../frontend/pkg'; \
+	else \
+		echo "Error: Homebrew LLVM not found. Install with: brew install llvm"; \
+		exit 1; \
+	fi
+else
 	cd wasm-module && wasm-pack build --target web --release --out-dir ../frontend/pkg
+endif
 
 .PHONY: build-cli
 build-cli: ## Build CLI tool


### PR DESCRIPTION
## Summary

- Add macOS support to CI runners
- Fix WASM build on macOS by using Homebrew LLVM

## Problem

Apple's system clang doesn't support the `wasm32-unknown-unknown` target required by `secp256k1-sys`, causing WASM builds to fail on macOS.

## Changes

- **CI**: Install Homebrew LLVM on macOS runners
- **Makefile**: Auto-detect macOS and use Homebrew LLVM for WASM compilation

Fixes #118