### PR TITLE
fix: refresh all wallet selects after saving wallet

### DIFF
--- a/frontend/js/wallet.js
+++ b/frontend/js/wallet.js
@@ -16,6 +16,8 @@ import {
   updateNotesDisplay,
   updateLedgerDisplay,
 } from "./scanner.js";
+import { populateAddressViewerWallets } from "./addresses.js";
+import { populateSendWallets } from "./send.js";
 
 let currentWalletData = null;
 
@@ -276,6 +278,8 @@ function saveWalletToBrowser() {
 
   updateSavedWalletsList();
   populateScannerWallets();
+  populateAddressViewerWallets();
+  populateSendWallets();
 
   const btn = document.getElementById("saveWalletBtn");
   if (btn) {


### PR DESCRIPTION
## Summary

- Refresh wallet select dropdowns in all views (scanner, address viewer, send) after saving a new wallet to browser storage
- Previously only the scanner wallet list was refreshed, requiring a page reload to see new wallets in other views

## Test plan

- [x] Create a new wallet
- [ ] Save it to browser storage
- [ ] Verify the wallet appears immediately in all wallet select dropdowns without page reload:
  - [ ] Scanner view
  - [ ] Address viewer
  - [ ] Send view

Fixes #123