### PR TITLE
feat: enable integrity verification in footer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ and this project adheres to
   [#116](https://github.com/LeakIX/zcash-web-wallet/pull/116))
 - Pin Rust nightly version for reproducible builds with weekly auto-update CI
   ([#129](https://github.com/LeakIX/zcash-web-wallet/issues/129))
+- Add integrity verification status indicator in footer
+  ([#127](https://github.com/LeakIX/zcash-web-wallet/pull/127))
 
 ### Changed
 

--- a/CHECKSUMS.json
+++ b/CHECKSUMS.json
@@ -1,6 +1,6 @@
 {
-  "version": "9ab0ab9eb1f013d7686c3e6e682989cc257a05c4",
-  "timestamp": "2026-01-01T13:47:38.315Z",
+  "version": "8340a8531eb061daf5a135919bf123e99ea3f187",
+  "timestamp": "2026-01-01T14:55:15.587Z",
   "files": {
     "js/app.js": "9504744a580c123a5f068ef546b3e3c6b8cd7ab41b16716187a4867eceac5524",
     "js/wasm.js": "d59292cdb2e7884ec9d8e05d1accc9f5ec81871119128580039fb6d014f7b8fd",
@@ -19,7 +19,7 @@
     "js/storage/wallets.js": "9810c2ad381e93b190c9df05b025a56f5d946a24037ebc7e2992d175b839af6e",
     "js/storage/ledger.js": "9c27db3ca5d269b6de53fdf5382ae36b4c12ccd9e87c7556387be6d28295f55c",
     "css/style.css": "e96edf0153354cbfd64beeb8912f1b8204784db62153949e67f3f80d54f0a5f6",
-    "index.html": "bcf4b0d0612d3988168847fc43ef5a80ce5f0d4ba49ba4679a49b3a0ca91c7d0",
+    "index.html": "7adb0e5a0e04b9579eed30295f21b085e343c71cf88ea16f8b40f949b467e740",
     "pkg/zcash_tx_viewer.js": "9305ddcfc88bd43fa38a38b38319b15f2984ce4f5bf93017d08ae4d633353557",
     "pkg/zcash_tx_viewer_bg.wasm": "9282204c32b4b5e9478815ef21eff333df457034996fd0bab31ed185cc78bba6"
   }

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1727,6 +1727,7 @@
       integrity="sha384-YvpcrYf0tY3lHB60NNkmXc5s9fDVZLESaAA55NDzOxhy9GkcIdslK1eN7N6jIeHz"
       crossorigin="anonymous"
     ></script>
+    <script src="integrity-check.js"></script>
     <script type="module" src="js/app.js"></script>
   </body>
 </html>


### PR DESCRIPTION
Add integrity-check.js script to index.html to enable the verification status indicator in the footer. The indicator shows:
- 'Verify' button (pending state)
- 'Verified' (success)
- 'Failed' (error)

Clicking the button runs manual verification with progress modal.