### PR TITLE
feat: pin Rust nightly version for reproducible builds

### DIFF
--- a/.github/scripts/get-latest-nightly.sh
+++ b/.github/scripts/get-latest-nightly.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+# Get the latest available Rust nightly version
+#
+# Usage: ./get-latest-nightly.sh
+# Output: nightly-YYYY-MM-DD
+
+set -euo pipefail
+
+# Get the latest available nightly version from rustup
+LATEST=$(rustup check 2>/dev/null | grep nightly | head -1 | \
+    grep -oE 'nightly-[0-9]{4}-[0-9]{2}-[0-9]{2}' || true)
+
+if [ -z "$LATEST" ]; then
+    # Fallback: use yesterday's date as nightly
+    # (nightly builds are typically available the day after)
+    if date --version >/dev/null 2>&1; then
+        # GNU date
+        LATEST="nightly-$(date -d 'yesterday' '+%Y-%m-%d')"
+    else
+        # BSD date (macOS)
+        LATEST="nightly-$(date -v-1d '+%Y-%m-%d')"
+    fi
+fi
+
+echo "$LATEST"

--- a/.github/scripts/update-rust-version.sh
+++ b/.github/scripts/update-rust-version.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+# Update Rust nightly version in all project files
+#
+# Usage: ./update-rust-version.sh <new-version>
+# Example: ./update-rust-version.sh nightly-2025-12-31
+
+set -euo pipefail
+
+if [ $# -ne 1 ]; then
+    echo "Usage: $0 <new-version>"
+    echo "Example: $0 nightly-2025-12-31"
+    exit 1
+fi
+
+NEW_VERSION="$1"
+
+# Validate format
+if ! echo "$NEW_VERSION" | grep -qE '^nightly-[0-9]{4}-[0-9]{2}-[0-9]{2}$'; then
+    echo "Error: Version must be in format nightly-YYYY-MM-DD"
+    exit 1
+fi
+
+# Get current version from rust-toolchain.toml
+OLD_VERSION=$(grep -oE 'nightly-[0-9]{4}-[0-9]{2}-[0-9]{2}' \
+    rust-toolchain.toml | head -1)
+
+if [ -z "$OLD_VERSION" ]; then
+    echo "Error: Could not find current version in rust-toolchain.toml"
+    exit 1
+fi
+
+if [ "$OLD_VERSION" = "$NEW_VERSION" ]; then
+    echo "Already at $NEW_VERSION"
+    exit 0
+fi
+
+echo "Updating from $OLD_VERSION to $NEW_VERSION"
+
+# Detect sed in-place flag (GNU vs BSD)
+if sed --version >/dev/null 2>&1; then
+    SED_INPLACE="sed -i"
+else
+    SED_INPLACE="sed -i ''"
+fi
+
+# Update rust-toolchain.toml
+$SED_INPLACE "s/$OLD_VERSION/$NEW_VERSION/g" rust-toolchain.toml
+echo "Updated rust-toolchain.toml"
+
+# Update Makefile
+$SED_INPLACE "s/$OLD_VERSION/$NEW_VERSION/g" Makefile
+echo "Updated Makefile"
+
+# Update CI workflow
+$SED_INPLACE "s/$OLD_VERSION/$NEW_VERSION/g" .github/workflows/ci.yml
+echo "Updated .github/workflows/ci.yml"
+
+echo "Done. Run 'git diff' to review changes."

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,8 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
+  # When updating RUST_NIGHTLY, also update rust-toolchain.toml and Makefile
+  RUST_NIGHTLY: nightly-2025-12-30
 
 jobs:
   rust:
@@ -19,17 +21,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install Rust nightly
-        uses: dtolnay/rust-toolchain@nightly
-        with:
-          components: rustfmt, clippy
-          targets: wasm32-unknown-unknown
-
       - name: Install LLVM (macOS)
         if: runner.os == 'macOS'
         run: brew install llvm
 
-      - name: Install wasm-pack
+      - name: Install Rust toolchain and wasm-pack
         run: make install-wasm-pack
 
       - name: Cache Cargo
@@ -71,10 +67,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install Rust nightly
-        uses: dtolnay/rust-toolchain@nightly
-        with:
-          components: rustfmt, clippy
+      - name: Install Rust toolchain
+        run: make install-wasm-pack
 
       - name: Cache Cargo
         uses: actions/cache@v4

--- a/.github/workflows/update-rust.yml
+++ b/.github/workflows/update-rust.yml
@@ -1,0 +1,83 @@
+name: Update Rust Nightly
+
+on:
+  schedule:
+    # Run every Monday at 09:00 UTC
+    - cron: "0 9 * * 1"
+  workflow_dispatch: # Allow manual trigger
+
+jobs:
+  update-rust:
+    name: Update Rust Nightly Version
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Get latest nightly date
+        id: get-nightly
+        run: |
+          # Get the latest available nightly version
+          LATEST=$(rustup check 2>/dev/null | grep nightly | head -1 | \
+            grep -oE 'nightly-[0-9]{4}-[0-9]{2}-[0-9]{2}' || true)
+
+          if [ -z "$LATEST" ]; then
+            # Fallback: use yesterday's date as nightly
+            LATEST="nightly-$(date -d 'yesterday' '+%Y-%m-%d')"
+          fi
+
+          echo "version=$LATEST" >> "$GITHUB_OUTPUT"
+          echo "Latest nightly: $LATEST"
+
+      - name: Get current version
+        id: get-current
+        run: |
+          CURRENT=$(grep -oE 'nightly-[0-9]{4}-[0-9]{2}-[0-9]{2}' \
+            rust-toolchain.toml | head -1)
+          echo "version=$CURRENT" >> "$GITHUB_OUTPUT"
+          echo "Current nightly: $CURRENT"
+
+      - name: Update version in files
+        if: steps.get-nightly.outputs.version != steps.get-current.outputs.version
+        env:
+          NEW_VERSION: ${{ steps.get-nightly.outputs.version }}
+          OLD_VERSION: ${{ steps.get-current.outputs.version }}
+        run: |
+          echo "Updating from $OLD_VERSION to $NEW_VERSION"
+
+          # Update rust-toolchain.toml
+          sed -i "s/$OLD_VERSION/$NEW_VERSION/g" rust-toolchain.toml
+
+          # Update Makefile
+          sed -i "s/$OLD_VERSION/$NEW_VERSION/g" Makefile
+
+          # Update CI workflow
+          sed -i "s/$OLD_VERSION/$NEW_VERSION/g" .github/workflows/ci.yml
+
+          # Show changes
+          git diff
+
+      - name: Create Pull Request
+        if: steps.get-nightly.outputs.version != steps.get-current.outputs.version
+        uses: peter-evans/create-pull-request@v7
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: "chore: update Rust nightly to ${{ steps.get-nightly.outputs.version }}"
+          title: "chore: update Rust nightly to ${{ steps.get-nightly.outputs.version }}"
+          body: |
+            Automated update of Rust nightly version.
+
+            **Changes:**
+            - `rust-toolchain.toml`
+            - `Makefile`
+            - `.github/workflows/ci.yml`
+
+            **From:** `${{ steps.get-current.outputs.version }}`
+            **To:** `${{ steps.get-nightly.outputs.version }}`
+
+            Please review and ensure CI passes before merging.
+          branch: chore/update-rust-nightly
+          base: develop
+          delete-branch: true

--- a/.github/workflows/update-rust.yml
+++ b/.github/workflows/update-rust.yml
@@ -19,15 +19,7 @@ jobs:
       - name: Get latest nightly date
         id: get-nightly
         run: |
-          # Get the latest available nightly version
-          LATEST=$(rustup check 2>/dev/null | grep nightly | head -1 | \
-            grep -oE 'nightly-[0-9]{4}-[0-9]{2}-[0-9]{2}' || true)
-
-          if [ -z "$LATEST" ]; then
-            # Fallback: use yesterday's date as nightly
-            LATEST="nightly-$(date -d 'yesterday' '+%Y-%m-%d')"
-          fi
-
+          LATEST=$(.github/scripts/get-latest-nightly.sh)
           echo "version=$LATEST" >> "$GITHUB_OUTPUT"
           echo "Latest nightly: $LATEST"
 
@@ -41,22 +33,8 @@ jobs:
 
       - name: Update version in files
         if: steps.get-nightly.outputs.version != steps.get-current.outputs.version
-        env:
-          NEW_VERSION: ${{ steps.get-nightly.outputs.version }}
-          OLD_VERSION: ${{ steps.get-current.outputs.version }}
         run: |
-          echo "Updating from $OLD_VERSION to $NEW_VERSION"
-
-          # Update rust-toolchain.toml
-          sed -i "s/$OLD_VERSION/$NEW_VERSION/g" rust-toolchain.toml
-
-          # Update Makefile
-          sed -i "s/$OLD_VERSION/$NEW_VERSION/g" Makefile
-
-          # Update CI workflow
-          sed -i "s/$OLD_VERSION/$NEW_VERSION/g" .github/workflows/ci.yml
-
-          # Show changes
+          .github/scripts/update-rust-version.sh "${{ steps.get-nightly.outputs.version }}"
           git diff
 
       - name: Create Pull Request

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to
 - Add code coverage with cargo-llvm-cov and Codecov integration
   ([#22](https://github.com/LeakIX/zcash-web-wallet/issues/22),
   [#116](https://github.com/LeakIX/zcash-web-wallet/pull/116))
+- Pin Rust nightly version for reproducible builds with weekly auto-update CI
+  ([#129](https://github.com/LeakIX/zcash-web-wallet/issues/129))
 
 ## [0.1.0] - 2025-12-30
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,16 +26,17 @@ make serve            # Build and serve frontend on port 3000
 ### Component-specific commands
 
 ```bash
-# Rust WASM module
-cd wasm-module && cargo +nightly test              # Run single test
-cd wasm-module && cargo +nightly clippy            # Lint
-cd wasm-module && cargo +nightly fmt               # Format
+# Rust
+make test-wasm-unit          # Run WASM module tests
+make test-cli                # Run CLI tests
+make lint-wasm               # Lint WASM module with clippy
+make lint-cli                # Lint CLI with clippy
+make format-rust             # Format Rust code
 
 # Frontend
-make format-check-js                               # Check JS/HTML formatting
-make format-check-sass                             # Check Sass formatting
-make build-sass                                    # Compile Sass to CSS
-make watch-sass                                    # Watch and recompile Sass
+make format-check-js         # Check JS/HTML formatting
+make build-sass              # Compile Sass to CSS
+make watch-sass              # Watch and recompile Sass
 ```
 
 ### Development server
@@ -97,8 +98,8 @@ data is fetched directly from the RPC endpoint the user selects.
 ### Formatting
 
 - **Always run `make format` before every commit and push**
-- Rust: `cargo +nightly fmt`
-- JS/HTML: `prettier --write`
+- Rust: `make format-rust`
+- JS/HTML: `make format-js`
 - Sass: indented syntax has strict formatting rules (no automated formatter)
 
 ### Pre-Commit Checklist

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "nightly"
+channel = "nightly-2025-12-30"
 components = ["rustfmt", "clippy"]
 targets = ["wasm32-unknown-unknown"]


### PR DESCRIPTION
Pin to nightly-2025-12-30 across rust-toolchain.toml, Makefile, and CI workflow. All cargo commands now use rustup run with the pinned version. Added sync reminders in all three files.

Closes #129