### PR TITLE
chore: enforce GNU sed on macOS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,9 +21,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install LLVM (macOS)
+      - name: Install macOS dependencies
         if: runner.os == 'macOS'
-        run: brew install llvm
+        run: brew install llvm gnu-sed
 
       - name: Install Rust toolchain and wasm-pack
         run: make install-wasm-pack
@@ -67,6 +67,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Install macOS dependencies
+        if: runner.os == 'macOS'
+        run: brew install gnu-sed
+
       - name: Install Rust toolchain
         run: make install-wasm-pack
 
@@ -102,6 +106,10 @@ jobs:
         os: [ubuntu-latest, macos-latest]
     steps:
       - uses: actions/checkout@v4
+
+      - name: Install macOS dependencies
+        if: runner.os == 'macOS'
+        run: brew install gnu-sed
 
       - name: Set up Node.js
         uses: actions/setup-node@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ and this project adheres to
 - Pin Rust nightly version for reproducible builds with weekly auto-update CI
   ([#129](https://github.com/LeakIX/zcash-web-wallet/issues/129))
 
+### Changed
+
+- Require GNU sed on macOS for Makefile targets (`brew install gnu-sed`)
+
 ## [0.1.0] - 2025-12-30
 
 ### Added

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,16 @@ WASM_PACK_VERSION := 0.13.1
 RUST_NIGHTLY := nightly-2025-12-30
 CARGO := rustup run $(RUST_NIGHTLY) cargo
 
+# Use GNU sed on macOS (install with: brew install gnu-sed)
+ifeq ($(shell uname),Darwin)
+    ifeq ($(shell which gsed 2>/dev/null),)
+        $(error GNU sed not found. Install with: brew install gnu-sed)
+    endif
+    SED := gsed
+else
+    SED := sed
+endif
+
 # =============================================================================
 # Default target
 # =============================================================================


### PR DESCRIPTION
## Summary

- Add `SED` variable to Makefile that uses `gsed` on macOS and `sed` on Linux
- Error with install instructions if `gsed` is not found on macOS

## Install

```bash
brew install coreutils
```