### PR TITLE
fix: use PAT for update-rust workflow

### DIFF
--- a/.github/workflows/update-rust.yml
+++ b/.github/workflows/update-rust.yml
@@ -41,7 +41,7 @@ jobs:
         if: steps.get-nightly.outputs.version != steps.get-current.outputs.version
         uses: peter-evans/create-pull-request@v7
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.PAT_WORKFLOW }}
           commit-message: "chore: update Rust nightly to ${{ steps.get-nightly.outputs.version }}"
           title: "chore: update Rust nightly to ${{ steps.get-nightly.outputs.version }}"
           body: |


### PR DESCRIPTION
## Summary

Use `PAT_WORKFLOW` secret instead of `GITHUB_TOKEN` to allow the workflow to
modify `.github/workflows/ci.yml`.

## Setup Required

Create a Personal Access Token with `workflows` permission and add it as a
repository secret named `PAT_WORKFLOW`.