### PR TITLE
chore: update Rust nightly to nightly-2025-12-31

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
 env:
   CARGO_TERM_COLOR: always
   # When updating RUST_NIGHTLY, also update rust-toolchain.toml and Makefile
-  RUST_NIGHTLY: nightly-2025-12-30
+  RUST_NIGHTLY: nightly-2025-12-31
 
 jobs:
   rust:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ and this project adheres to
 
 ### Changed
 
+- Update Rust nightly to `nightly-2025-12-31`
+  ([#138](https://github.com/LeakIX/zcash-web-wallet/pull/138))
+
 - Require GNU sed on macOS for Makefile targets (`brew install gnu-sed`)
 - CI now uses git-based check to verify generated files are committed separately
   ([#130](https://github.com/LeakIX/zcash-web-wallet/pull/130))

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@
 WASM_PACK_VERSION := 0.13.1
 # When updating RUST_NIGHTLY, also update rust-toolchain.toml and
 # .github/workflows/ci.yml
-RUST_NIGHTLY := nightly-2025-12-30
+RUST_NIGHTLY := nightly-2025-12-31
 CARGO := rustup run $(RUST_NIGHTLY) cargo
 
 # Use GNU sed on macOS (install with: brew install gnu-sed)

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "nightly-2025-12-30"
+channel = "nightly-2025-12-31"
 components = ["rustfmt", "clippy"]
 targets = ["wasm32-unknown-unknown"]


### PR DESCRIPTION
Automated update of Rust nightly version.

**Changes:**
- `rust-toolchain.toml`
- `Makefile`
- `.github/workflows/ci.yml`
- `CHANGELOG.md`

**From:** `nightly-2025-12-30`
**To:** `nightly-2025-12-31`

Please review and ensure CI passes before merging.