### PR TITLE
fix: remove duplicate format-check-cli target in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -150,11 +150,6 @@ format-check-cli: ## Check CLI Rust formatting
 	@echo "Checking CLI formatting..."
 	$(CARGO) fmt -p zcash-wallet-cli --check
 
-.PHONY: format-check-cli
-format-check-cli: ## Check CLI Rust formatting
-	@echo "Checking CLI formatting..."
-	cargo +nightly fmt -p zcash-wallet-cli --check
-
 .PHONY: format-check-toml
 format-check-toml: ## Check TOML formatting with taplo
 	@echo "Checking TOML formatting..."


### PR DESCRIPTION
## Summary
- Remove duplicate `format-check-cli` target in Makefile that was using unpinned `cargo +nightly` instead of `$(CARGO)`

This was causing CI format checks to fail because the second target definition overrode the first and used an unpinned nightly version.

## Test plan
- [ ] CI format check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)