### PR TITLE
fix: verify checksums before deploying to GitHub Pages

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -24,6 +24,18 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+          cache: "npm"
+
+      - name: Install npm dependencies
+        run: npm ci
+
+      - name: Verify checksums
+        run: make verify-checksums
+
       - name: Setup Pages
         uses: actions/configure-pages@v5
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,8 @@ and this project adheres to
   ([#148](https://github.com/LeakIX/zcash-web-wallet/pull/148))
 - CI should not run code coverage on main
   ([#150](https://github.com/LeakIX/zcash-web-wallet/pull/150))
+- Deploy workflow verifies checksums before publishing to GitHub Pages
+  ([#151](https://github.com/LeakIX/zcash-web-wallet/pull/151))
 
 ## [Unreleased]
 


### PR DESCRIPTION
## Summary
- Add checksum verification step to deploy workflow
- Ensures deployed files match committed checksums before publishing

## Test plan
- [ ] Deploy workflow verifies checksums before uploading