### PR TITLE
feat: add version update notification for users

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -19,6 +19,24 @@
   </head>
   <body>
     <div class="container py-5">
+      <!-- Version update notification -->
+      <div
+        id="versionUpdateBanner"
+        class="alert alert-info alert-dismissible d-none mb-4"
+        role="alert"
+      >
+        <i class="bi bi-info-circle me-2"></i>
+        <strong>App updated!</strong> This app has been updated since your last
+        visit (<code id="oldVersionHash"></code> &rarr;
+        <code id="newVersionHash"></code>).
+        <button
+          type="button"
+          class="btn-close"
+          id="dismissVersionBanner"
+          aria-label="Close"
+        ></button>
+      </div>
+
       <header class="mb-4">
         <div
           class="d-flex justify-content-between align-items-start flex-wrap gap-3"
@@ -1661,12 +1679,12 @@
             <span class="d-block d-sm-inline">
               <span class="d-none d-sm-inline">&mdash;</span>
               <a
-                href="https://github.com/LeakIX/zcash-web-wallet/commit/__COMMIT_HASH__"
+                href="https://github.com/LeakIX/zcash-web-wallet/commit/9156c6941b5ccd2b366fe4a7936e50562169badd"
                 target="_blank"
                 rel="noopener noreferrer"
                 class="text-muted"
                 id="commitLink"
-                >__COMMIT_SHORT__</a
+                >9156c69</a
               >
             </span>
           </p>

--- a/frontend/js/app.js
+++ b/frontend/js/app.js
@@ -16,9 +16,19 @@ import { initWalletUI } from "./wallet.js";
 import { initAddressViewerUI } from "./addresses.js";
 import { initSendUI } from "./send.js";
 import { initViewModeUI } from "./views.js";
+import { initVersionCheck, dismissUpdateBanner } from "./version.js";
 
 // Initialize application on page load
 document.addEventListener("DOMContentLoaded", async () => {
+  // Check for version updates
+  initVersionCheck();
+
+  // Set up version banner dismiss button
+  const dismissBtn = document.getElementById("dismissVersionBanner");
+  if (dismissBtn) {
+    dismissBtn.addEventListener("click", dismissUpdateBanner);
+  }
+
   // Set initial theme
   setTheme(getPreferredTheme());
 

--- a/frontend/js/constants.js
+++ b/frontend/js/constants.js
@@ -11,6 +11,7 @@ export const STORAGE_KEYS = {
   ledger: "zcash_viewer_ledger",
   viewMode: "zcash_viewer_view_mode",
   theme: "zcash_viewer_theme",
+  appVersion: "zcash_viewer_app_version",
 };
 
 // View modes: simple, accountant, admin

--- a/frontend/js/version.js
+++ b/frontend/js/version.js
@@ -1,0 +1,122 @@
+// Zcash Web Wallet - Version Notification
+// Notifies users when a new version of the app is available
+
+import { STORAGE_KEYS } from "./constants.js";
+
+/**
+ * Get the current app version (commit hash) from the page.
+ * The commit hash is embedded in the commitLink href during build.
+ * @returns {string|null} The commit hash or null if not found/placeholder
+ */
+function getCurrentVersion() {
+  const commitLink = document.getElementById("commitLink");
+  if (!commitLink) return null;
+
+  const href = commitLink.getAttribute("href");
+  if (!href) return null;
+
+  // Extract commit hash from URL: .../commit/{hash}
+  const match = href.match(/\/commit\/([a-f0-9]+)$/i);
+  if (!match) return null;
+
+  const hash = match[1];
+
+  // Ignore placeholder value (not yet injected)
+  if (hash === "__COMMIT_HASH__") return null;
+
+  return hash;
+}
+
+/**
+ * Get the stored version from localStorage.
+ * @returns {string|null} The stored version or null
+ */
+function getStoredVersion() {
+  try {
+    return localStorage.getItem(STORAGE_KEYS.appVersion);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Store the current version in localStorage.
+ * @param {string} version - The version to store
+ */
+function storeVersion(version) {
+  try {
+    localStorage.setItem(STORAGE_KEYS.appVersion, version);
+  } catch {
+    // Ignore storage errors
+  }
+}
+
+/**
+ * Get the short version of a commit hash.
+ * @param {string} hash - Full commit hash
+ * @returns {string} Short hash (first 7 characters)
+ */
+function shortHash(hash) {
+  return hash.substring(0, 7);
+}
+
+/**
+ * Show the version update notification banner.
+ * @param {string} oldVersion - The previous version hash
+ * @param {string} newVersion - The current version hash
+ */
+function showUpdateBanner(oldVersion, newVersion) {
+  const banner = document.getElementById("versionUpdateBanner");
+  const oldHashEl = document.getElementById("oldVersionHash");
+  const newHashEl = document.getElementById("newVersionHash");
+
+  if (oldHashEl) {
+    oldHashEl.textContent = shortHash(oldVersion);
+  }
+  if (newHashEl) {
+    newHashEl.textContent = shortHash(newVersion);
+  }
+  if (banner) {
+    banner.classList.remove("d-none");
+  }
+}
+
+/**
+ * Hide the version update notification banner and update stored version.
+ */
+export function dismissUpdateBanner() {
+  const banner = document.getElementById("versionUpdateBanner");
+  if (banner) {
+    banner.classList.add("d-none");
+  }
+
+  // Update stored version to current
+  const currentVersion = getCurrentVersion();
+  if (currentVersion) {
+    storeVersion(currentVersion);
+  }
+}
+
+/**
+ * Initialize version checking.
+ * Compares current version with stored version and shows notification if different.
+ */
+export function initVersionCheck() {
+  const currentVersion = getCurrentVersion();
+
+  // No version available (placeholder or missing)
+  if (!currentVersion) return;
+
+  const storedVersion = getStoredVersion();
+
+  // First visit - store current version
+  if (!storedVersion) {
+    storeVersion(currentVersion);
+    return;
+  }
+
+  // Version changed - show notification
+  if (storedVersion !== currentVersion) {
+    showUpdateBanner(storedVersion, currentVersion);
+  }
+}


### PR DESCRIPTION
- Store app version (commit hash) in localStorage on first visit
- Compare stored version with current version on page load
- Show info banner when a new version is available
- User can dismiss banner to acknowledge the update