### PR TITLE
feat: add mobile and responsive testing support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -158,8 +158,11 @@ jobs:
       - name: Install Playwright
         run: make install-playwright
 
-      - name: Run E2E tests
-        run: make test-e2e-frontend
+      - name: Run E2E tests (Desktop)
+        run: make test-e2e-frontend-desktop
+
+      - name: Run E2E tests (Mobile Chrome)
+        run: make test-e2e-frontend-mobile-chrome
 
       - uses: actions/upload-artifact@v4
         if: always()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -164,6 +164,9 @@ jobs:
       - name: Run E2E tests (Mobile Chrome)
         run: make test-e2e-frontend-mobile-chrome
 
+      - name: Run E2E tests (Mobile Safari)
+        run: make test-e2e-frontend-mobile-safari
+
       - uses: actions/upload-artifact@v4
         if: always()
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,8 +19,8 @@ and this project adheres to
 - Add mobile responsive testing with Playwright
   ([#176](https://github.com/LeakIX/zcash-web-wallet/issues/176),
   [#179](https://github.com/LeakIX/zcash-web-wallet/pull/179))
-  - Add mobile Chrome device profile (Pixel 5)
-  - Run E2E tests on desktop and mobile Chrome in CI
+  - Add mobile device profiles (Pixel 5, iPhone 12)
+  - Run E2E tests on desktop, mobile Chrome, and mobile Safari in CI
 
 ## 0.2.0 - 20260101
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,11 @@ and this project adheres to
   - Add render functions for balance cards, notes, transactions, and empty
     states
   - First step toward moving DOM manipulation from JavaScript to Rust/WASM
+- Add mobile responsive testing with Playwright
+  ([#176](https://github.com/LeakIX/zcash-web-wallet/issues/176),
+  [#179](https://github.com/LeakIX/zcash-web-wallet/pull/179))
+  - Add mobile Chrome device profile (Pixel 5)
+  - Run E2E tests on desktop and mobile Chrome in CI
 
 ## 0.2.0 - 20260101
 

--- a/Makefile
+++ b/Makefile
@@ -230,9 +230,24 @@ test-e2e: build-cli ## Run CLI end-to-end tests
 	cli/e2e/test_cli.sh
 
 .PHONY: test-e2e-frontend
-test-e2e-frontend: build ## Run frontend end-to-end tests
+test-e2e-frontend: build ## Run frontend e2e tests (all devices)
 	@echo "Running frontend e2e tests..."
 	npx playwright test
+
+.PHONY: test-e2e-frontend-desktop
+test-e2e-frontend-desktop: build ## Run frontend e2e tests on desktop Chrome only
+	@echo "Running frontend e2e tests (desktop)..."
+	npx playwright test --project=chromium
+
+.PHONY: test-e2e-frontend-mobile-chrome
+test-e2e-frontend-mobile-chrome: build ## Run frontend e2e tests on mobile Chrome only
+	@echo "Running frontend e2e tests (mobile Chrome)..."
+	npx playwright test --project=mobile-chrome
+
+.PHONY: test-e2e-frontend-mobile-safari
+test-e2e-frontend-mobile-safari: build ## Run frontend e2e tests on mobile Safari only
+	@echo "Running frontend e2e tests (mobile Safari)..."
+	npx playwright test --project=mobile-safari
 
 .PHONY: test-e2e-frontend-ui
 test-e2e-frontend-ui: build ## Run frontend e2e tests in UI mode

--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ install-npm: ## Install npm dependencies (Prettier, Sass)
 .PHONY: install-playwright
 install-playwright: ## Install Playwright browsers
 	@echo "Installing Playwright browsers..."
-	npx playwright install --with-deps chromium
+	npx playwright install --with-deps chromium webkit
 
 # =============================================================================
 # Building

--- a/frontend/e2e/helpers.js
+++ b/frontend/e2e/helpers.js
@@ -36,20 +36,40 @@ export async function waitForWasmLoad(page) {
   );
 }
 
-export async function switchToAdminView(page) {
-  const viewModeRadio = page.locator("#viewAdmin");
-  if (!(await viewModeRadio.isChecked())) {
-    // Click the label, not the hidden radio input
-    await page.locator('label[for="viewAdmin"]').click();
+async function switchViewMode(page, mode) {
+  // Check if mobile dropdown is visible
+  const mobileDropdown = page.locator("#viewModeDropdown");
+  const isMobile = await mobileDropdown.isVisible();
+
+  if (isMobile) {
+    // Mobile: Use dropdown
+    await mobileDropdown.click();
+    await page.locator(`button[data-view-mode="${mode}"]`).click();
+  } else {
+    // Desktop: Use radio button labels
+    const viewModeRadio = page.locator(
+      `#view${mode.charAt(0).toUpperCase() + mode.slice(1)}`
+    );
+    if (!(await viewModeRadio.isChecked())) {
+      await page
+        .locator(
+          `label[for="view${mode.charAt(0).toUpperCase() + mode.slice(1)}"]`
+        )
+        .click();
+    }
   }
 }
 
+export async function switchToAdminView(page) {
+  await switchViewMode(page, "admin");
+}
+
 export async function switchToSimpleView(page) {
-  const viewModeRadio = page.locator("#viewSimple");
-  if (!(await viewModeRadio.isChecked())) {
-    // Click the label, not the hidden radio input
-    await page.locator('label[for="viewSimple"]').click();
-  }
+  await switchViewMode(page, "simple");
+}
+
+export async function switchToAccountantView(page) {
+  await switchViewMode(page, "accountant");
 }
 
 export async function navigateToTab(page, tabId) {

--- a/frontend/e2e/theme.spec.js
+++ b/frontend/e2e/theme.spec.js
@@ -3,6 +3,7 @@ import {
   clearLocalStorage,
   switchToSimpleView,
   switchToAdminView,
+  switchToAccountantView,
   waitForWasmLoad,
 } from "./helpers.js";
 
@@ -88,7 +89,7 @@ test.describe("View Mode", () => {
   });
 
   test("should switch to accountant view", async ({ page }) => {
-    await page.locator('label[for="viewAccountant"]').click();
+    await switchToAccountantView(page);
 
     await expect(page.locator("#viewAccountant")).toBeChecked();
   });

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -22,6 +22,14 @@ export default defineConfig({
       name: "chromium",
       use: { ...devices["Desktop Chrome"] },
     },
+    {
+      name: "mobile-chrome",
+      use: { ...devices["Pixel 5"] },
+    },
+    {
+      name: "mobile-safari",
+      use: { ...devices["iPhone 12"] },
+    },
   ],
   webServer: {
     command: "cd frontend && python3 -m http.server 3000",


### PR DESCRIPTION
## Summary

Add mobile device testing to the E2E test suite to ensure the wallet works correctly on various screen sizes and mobile devices.

Closes #176

## Changes

### Playwright Configuration
- Add mobile device profiles:
  - `mobile-chrome` (Pixel 5)
  - `mobile-safari` (iPhone 12)

### Test Helpers
- Update `switchViewMode()` to detect mobile viewport and use dropdown menu instead of desktop radio buttons
- Add `switchToAccountantView()` helper function
- Fix accountant view test to use the new helper

### Makefile
- Add device-specific test targets:
  - `make test-e2e-frontend-desktop` - Desktop Chrome only
  - `make test-e2e-frontend-mobile-chrome` - Mobile Chrome only
  - `make test-e2e-frontend-mobile-safari` - Mobile Safari only
- Keep `make test-e2e-frontend` to run all devices

### CI
- Split E2E tests into separate steps for desktop and mobile-chrome
- Both run on ubuntu-latest and macos-latest

## Test Results

```
Desktop Chrome: 78 passed (13.8s)
Mobile Chrome:  78 passed (20.6s)
```

## Test plan

- [x] All 78 tests pass on Desktop Chrome
- [x] All 78 tests pass on Mobile Chrome (Pixel 5 emulation)
- [x] View mode switching works on mobile (dropdown menu)
- [x] CI configuration updated