### PR TITLE
ci: optimize E2E tests by using committed artifacts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -141,7 +141,7 @@ jobs:
 
       - name: Install macOS dependencies
         if: runner.os == 'macOS'
-        run: brew install llvm gnu-sed
+        run: brew install gnu-sed
 
       - name: Set up Node.js
         uses: actions/setup-node@v4
@@ -149,15 +149,14 @@ jobs:
           node-version: "24"
           cache: "npm"
 
-      - name: Install Rust toolchain and wasm-pack
-        run: make install-wasm-pack
-
       - name: Install npm dependencies
         run: make install-npm
 
       - name: Install Playwright
         run: make install-playwright
 
+      # E2E tests use committed artifacts (WASM, CSS) directly
+      # Build jobs verify artifacts can be built; E2E jobs verify functionality
       - name: Run E2E tests (Desktop)
         run: make test-e2e-frontend-desktop
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,12 @@ and this project adheres to
   ([#181](https://github.com/LeakIX/zcash-web-wallet/issues/181),
   [#183](https://github.com/LeakIX/zcash-web-wallet/pull/183))
 
+### Changed
+
+- Optimize CI: E2E tests use committed artifacts instead of rebuilding
+  ([#180](https://github.com/LeakIX/zcash-web-wallet/issues/180),
+  [#184](https://github.com/LeakIX/zcash-web-wallet/pull/184))
+
 ## 0.2.0 - 20260101
 
 ### Added

--- a/Makefile
+++ b/Makefile
@@ -229,28 +229,31 @@ test-e2e: build-cli ## Run CLI end-to-end tests
 	@echo "Running CLI e2e tests..."
 	cli/e2e/test_cli.sh
 
+# Frontend E2E test targets
+# In CI (CI=true), skip build and use committed artifacts
+# Locally, rebuild before testing
 .PHONY: test-e2e-frontend
-test-e2e-frontend: build ## Run frontend e2e tests (all devices)
+test-e2e-frontend: $(if $(CI),,build) ## Run frontend e2e tests (all devices)
 	@echo "Running frontend e2e tests..."
 	npx playwright test
 
 .PHONY: test-e2e-frontend-desktop
-test-e2e-frontend-desktop: build ## Run frontend e2e tests on desktop Chrome only
+test-e2e-frontend-desktop: $(if $(CI),,build) ## Run frontend e2e tests on desktop Chrome only
 	@echo "Running frontend e2e tests (desktop)..."
 	npx playwright test --project=chromium
 
 .PHONY: test-e2e-frontend-mobile-chrome
-test-e2e-frontend-mobile-chrome: build ## Run frontend e2e tests on mobile Chrome only
+test-e2e-frontend-mobile-chrome: $(if $(CI),,build) ## Run frontend e2e tests on mobile Chrome only
 	@echo "Running frontend e2e tests (mobile Chrome)..."
 	npx playwright test --project=mobile-chrome
 
 .PHONY: test-e2e-frontend-mobile-safari
-test-e2e-frontend-mobile-safari: build ## Run frontend e2e tests on mobile Safari only
+test-e2e-frontend-mobile-safari: $(if $(CI),,build) ## Run frontend e2e tests on mobile Safari only
 	@echo "Running frontend e2e tests (mobile Safari)..."
 	npx playwright test --project=mobile-safari
 
 .PHONY: test-e2e-frontend-ui
-test-e2e-frontend-ui: build ## Run frontend e2e tests in UI mode
+test-e2e-frontend-ui: $(if $(CI),,build) ## Run frontend e2e tests in UI mode
 	@echo "Running frontend e2e tests in UI mode..."
 	npx playwright test --ui
 


### PR DESCRIPTION
## Summary

- Remove Rust toolchain and wasm-pack installation from E2E job
- Add conditional build in Makefile: skip build when `CI=true`
- E2E tests now use committed WASM/CSS artifacts directly
- Build jobs verify artifacts can be built; E2E jobs verify functionality

## Changes

### Makefile
```makefile
# Before: always rebuild
test-e2e-frontend-desktop: build

# After: skip build in CI, rebuild locally
test-e2e-frontend-desktop: $(if $(CI),,build)
```

### CI Workflow
- Removed: `brew install llvm gnu-sed` (macOS only needed for WASM build)
- Removed: `make install-wasm-pack` (Rust toolchain not needed)
- E2E jobs now only install Node.js, npm, and Playwright

## Expected Benefits

- ~2-3 minutes faster per E2E job (skip Rust/WASM build)
- Reduced CI resource usage
- Clearer separation: build jobs verify builds, E2E jobs verify functionality
- Tests run on exact artifacts that will be deployed

## Test plan

- [x] Verify E2E tests pass without Rust toolchain
- [x] Verify local `make test-e2e-frontend-desktop` still rebuilds

Closes #180