### PR TITLE
chore: add repository field to Cargo.toml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,9 @@ and this project adheres to
 - Add MIT LICENSE file
   ([#181](https://github.com/LeakIX/zcash-web-wallet/issues/181),
   [#183](https://github.com/LeakIX/zcash-web-wallet/pull/183))
+- Add repository field to Cargo.toml
+  ([#182](https://github.com/LeakIX/zcash-web-wallet/issues/182),
+  [#185](https://github.com/LeakIX/zcash-web-wallet/pull/185))
 
 ### Changed
 

--- a/CHECKSUMS.json
+++ b/CHECKSUMS.json
@@ -1,6 +1,6 @@
 {
-  "version": "d536676bc4cec261fa4c1e689d621dfb3e62f390",
-  "timestamp": "2026-01-03T11:32:09.027Z",
+  "version": "99ac191076a7bbdc2a4965806b25c6d4500c562b",
+  "timestamp": "2026-01-03T11:41:50.044Z",
   "files": {
     "js/app.js": "64fc865eb0fd2ce589abdc176a0af3fff5653ee8a6e619e75702b162469ead8c",
     "js/wasm.js": "d59292cdb2e7884ec9d8e05d1accc9f5ec81871119128580039fb6d014f7b8fd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ members = ["core", "wasm-module", "cli"]
 version = "0.1.0"
 edition = "2024"
 license = "MIT"
+repository = "https://github.com/LeakIX/zcash-web-wallet"
 
 [workspace.dependencies]
 # HTML builder

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -3,6 +3,7 @@ name = "zcash-wallet-cli"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+repository.workspace = true
 description = "CLI tool for generating Zcash testnet wallets"
 
 [[bin]]

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -3,6 +3,7 @@ name = "zcash-wallet-core"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+repository.workspace = true
 description = "Core library for Zcash wallet derivation and transaction scanning"
 
 [dependencies]

--- a/frontend/pkg/package.json
+++ b/frontend/pkg/package.json
@@ -4,6 +4,10 @@
   "description": "WASM module for decrypting Zcash shielded transactions",
   "version": "0.1.0",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/LeakIX/zcash-web-wallet"
+  },
   "files": [
     "zcash_tx_viewer_bg.wasm",
     "zcash_tx_viewer.js",

--- a/wasm-module/Cargo.toml
+++ b/wasm-module/Cargo.toml
@@ -3,6 +3,7 @@ name = "zcash-tx-viewer"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+repository.workspace = true
 description = "WASM module for decrypting Zcash shielded transactions"
 
 [lib]


### PR DESCRIPTION
## Summary

Add `repository` field to workspace package metadata and inherit it in all crates.

Fixes wasm-pack info message:
```
[INFO]: Optional field missing from Cargo.toml: 'repository'
```

## Changes

- Add `repository = "https://github.com/LeakIX/zcash-web-wallet"` to `[workspace.package]`
- Add `repository.workspace = true` to core, wasm-module, and cli Cargo.toml files

## Test plan

- [x] Verify `make build-wasm` no longer shows repository warning

Closes #182