### PR TITLE
chore: update Rust nightly to nightly-2026-02-08

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
 env:
   CARGO_TERM_COLOR: always
   # When updating RUST_NIGHTLY, also update rust-toolchain.toml and Makefile
-  RUST_NIGHTLY: nightly-2025-12-31
+  RUST_NIGHTLY: nightly-2026-02-08
 
 jobs:
   rust:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ and this project adheres to
 
 ### Changed
 
+- Update Rust nightly to `nightly-2026-02-08`
+  ([#230](https://github.com/LeakIX/zcash-web-wallet/pull/230))
+
 - Replace `key_type` string field with `ViewingKeyType` enum in `ViewingKeyInfo`
   for better type safety
   ([#97](https://github.com/LeakIX/zcash-web-wallet/issues/97))
@@ -49,6 +52,9 @@ and this project adheres to
   - Add render_contacts_list(), render_contacts_dropdown() WASM functions
 
 ### Changed
+
+- Update Rust nightly to `nightly-2026-02-08`
+  ([#230](https://github.com/LeakIX/zcash-web-wallet/pull/230))
 
 - Optimize CI: E2E tests use committed artifacts instead of rebuilding
   ([#180](https://github.com/LeakIX/zcash-web-wallet/issues/180),
@@ -114,6 +120,9 @@ and this project adheres to
   ([#158](https://github.com/LeakIX/zcash-web-wallet/pull/158))
 
 ### Changed
+
+- Update Rust nightly to `nightly-2026-02-08`
+  ([#230](https://github.com/LeakIX/zcash-web-wallet/pull/230))
 
 - Consolidate `pages-build` CI job into deploy workflow
   ([#152](https://github.com/LeakIX/zcash-web-wallet/pull/152))

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@
 WASM_PACK_VERSION := 0.13.1
 # When updating RUST_NIGHTLY, also update rust-toolchain.toml and
 # .github/workflows/ci.yml
-RUST_NIGHTLY := nightly-2025-12-31
+RUST_NIGHTLY := nightly-2026-02-08
 CARGO := rustup run $(RUST_NIGHTLY) cargo
 
 # Use GNU sed on macOS (install with: brew install gnu-sed)

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "nightly-2025-12-31"
+channel = "nightly-2026-02-08"
 components = ["rustfmt", "clippy"]
 targets = ["wasm32-unknown-unknown"]


### PR DESCRIPTION
Automated update of Rust nightly version.

**Changes:**
- `rust-toolchain.toml`
- `Makefile`
- `.github/workflows/ci.yml`
- `CHANGELOG.md`

**From:** `nightly-2025-12-31`
**To:** `nightly-2026-02-08`

Please review and ensure CI passes before merging.