### PR TITLE
chore: update Rust nightly to nightly-2026-03-29

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
 env:
   CARGO_TERM_COLOR: always
   # When updating RUST_NIGHTLY, also update rust-toolchain.toml and Makefile
-  RUST_NIGHTLY: nightly-2025-12-31
+  RUST_NIGHTLY: nightly-2026-03-29
 
 jobs:
   rust:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ and this project adheres to
 
 ### Changed
 
+- Update Rust nightly to `nightly-2026-03-29`
+  ([#244](https://github.com/LeakIX/zcash-web-wallet/pull/244))
+
 - Replace `key_type` string field with `ViewingKeyType` enum in `ViewingKeyInfo`
   for better type safety
   ([#97](https://github.com/LeakIX/zcash-web-wallet/issues/97))
@@ -49,6 +52,9 @@ and this project adheres to
   - Add render_contacts_list(), render_contacts_dropdown() WASM functions
 
 ### Changed
+
+- Update Rust nightly to `nightly-2026-03-29`
+  ([#244](https://github.com/LeakIX/zcash-web-wallet/pull/244))
 
 - Optimize CI: E2E tests use committed artifacts instead of rebuilding
   ([#180](https://github.com/LeakIX/zcash-web-wallet/issues/180),
@@ -114,6 +120,9 @@ and this project adheres to
   ([#158](https://github.com/LeakIX/zcash-web-wallet/pull/158))
 
 ### Changed
+
+- Update Rust nightly to `nightly-2026-03-29`
+  ([#244](https://github.com/LeakIX/zcash-web-wallet/pull/244))
 
 - Consolidate `pages-build` CI job into deploy workflow
   ([#152](https://github.com/LeakIX/zcash-web-wallet/pull/152))

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@
 WASM_PACK_VERSION := 0.13.1
 # When updating RUST_NIGHTLY, also update rust-toolchain.toml and
 # .github/workflows/ci.yml
-RUST_NIGHTLY := nightly-2025-12-31
+RUST_NIGHTLY := nightly-2026-03-29
 CARGO := rustup run $(RUST_NIGHTLY) cargo
 
 # Use GNU sed on macOS (install with: brew install gnu-sed)

--- a/README.md
+++ b/README.md
@@ -7,7 +7,8 @@ A privacy-preserving Zcash wallet toolkit that runs entirely in your browser.
 Generate wallets, view shielded transactions, and track balances - all
 client-side with no server dependencies.
 
-This project is vibe-coded. It was an attempt to see how AI code assistants perform back then.
+This project is vibe-coded. It was an attempt to see how AI code assistants
+perform back then.
 
 ## Features
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "nightly-2025-12-31"
+channel = "nightly-2026-03-29"
 components = ["rustfmt", "clippy"]
 targets = ["wasm32-unknown-unknown"]


### PR DESCRIPTION
Automated update of Rust nightly version.

**Changes:**
- `rust-toolchain.toml`
- `Makefile`
- `.github/workflows/ci.yml`
- `CHANGELOG.md`

**From:** `nightly-2025-12-31`
**To:** `nightly-2026-03-29`

Please review and ensure CI passes before merging.